### PR TITLE
[#7] 인풋 컴포넌트 구현

### DIFF
--- a/src/components/test/ui/input/InputTest.tsx
+++ b/src/components/test/ui/input/InputTest.tsx
@@ -4,11 +4,16 @@ import { useState } from "react"
 import { NormalInput } from "@/components/ui/input/NormalInput" 
 import { NormalInput2 } from "@/components/ui/input/NormalInput2"
 import { PasswordInput } from "@/components/ui/input/PasswordInput";
+import { Toggle } from "@/components/ui/input/Toggle"; 
+import { DisabledInputField } from "@/components/ui/input/DisabledInputField";
+import { FlexibleInputField } from "@/components/ui/input/FlexibleInputField";
 
 export default function InputTest() {
   const [text, setText] = useState("");
   const [text2, setText2] = useState("");
+  const [text3, setText3] = useState("");
   const [password, setPassword] = useState("")
+  const [isOn, setIsOn] = useState(false);
 
   return (
     <div className="min-h-screen bg-[#fafcff] p-8">
@@ -45,6 +50,57 @@ export default function InputTest() {
           <p className="text-body-07 text-[#363d4e]">
             <span className="font-semibold">입력된 비밀번호:</span> {password || "(없음)"}
           </p>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-md space-y-6">
+        <h1 className="text-head-02 text-[#343434] mb-10 mt-20">테스트4</h1>
+
+        {/** toggle switch component */}
+        <div className="flex items-center gap-4">
+          <Toggle isOn={isOn} setIsOn={setIsOn} />
+          <span className="text-body-06 text-[#989898]">토글을 클릭해보세요</span>
+        </div>
+
+        {/** display current state for testing */}
+        <div className="mt-8 p-4 bg-[#f7f9a7] rounded-lg">
+          <p className="text-body-07 text-[#343434]">
+            <span className="font-semibold">현재 상태:</span> {isOn ? "ON (켜짐)" : "OFF (꺼짐)"}
+          </p>
+        </div>
+      </div>
+
+      <div className="w-full max-w-md space-y-8">
+        {/** title */}
+        <h1 className="text-head-03 text-neutral-1 whitespace-pre-line mt-10">{"비활성화된 입력 필드 테스트"}</h1>
+
+        {/** disabled input field component */}
+        <DisabledInputField label="이것은 라벨" content="이것은 비활성화된 인풋" />
+      </div>
+
+      <div className="w-full max-w-md space-y-8">
+        {/** title */}
+        <h1 className="text-head-03 text-[#343434] whitespace-pre-line mt-10">{"유연한 입력 필드 테스트"}</h1>
+
+        {/** enabled input field component */}
+        <div className="space-y-4">
+          <h2 className="text-head-06 text-[#343434]">활성화된 입력 필드</h2>
+          <FlexibleInputField
+            label="이만큼 더 필요해요"
+            enabled={true}
+            text={text3}
+            setText={setText3}
+            placeholder="금액을 입력하세요"
+          />
+          <p className="text-body-07 text-[#989898]">
+            현재 입력된 값: <span className="text-[#343434] font-medium">{text3 || "(없음)"}</span>
+          </p>
+        </div>
+
+        {/** disabled input field component */}
+        <div className="space-y-4">
+          <h2 className="text-head-06 text-[#343434]">비활성화된 입력 필드</h2>
+          <FlexibleInputField label="이만큼 더 필요해요" enabled={false} content="10,000,000" />
         </div>
       </div>
     </div>

--- a/src/components/ui/input/DisabledInputField.tsx
+++ b/src/components/ui/input/DisabledInputField.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+/**
+ * DisabledInputFieldProps
+ * @typedef {Object} DisabledInputFieldProps
+ * @property {string} label - 입력 필드 상단에 표시될 라벨 텍스트입니다.
+ * @property {string} content - 비활성화된 입력 필드에 표시될 내용입니다.
+ */
+interface DisabledInputFieldProps {
+  label: string
+  content: string
+}
+
+/**
+ * DisabledInputField
+ *
+ * 정보 확인용으로 사용되는 비활성화된 입력 필드 컴포넌트입니다.
+ * 사용자가 텍스트를 입력할 수 없으며, 오직 정보를 표시하는 용도로만 사용됩니다.
+ *
+ * ### 특징
+ * - 입력이 완전히 비활성화되어 있습니다 (`disabled` 속성).
+ * - `label`과 `content`를 props로 받아 표시합니다.
+ * - `whitespace-pre-line`을 사용하여 줄바꿈을 유연하게 처리합니다.
+ *
+ * ### 시각적 구성
+ * - 상단에 라벨 텍스트 (`text-[#343434]`)
+ * - 하단에 비활성화된 입력 필드 (`bg-[#e8ebee]`)
+ * - 입력 필드는 읽기 전용이며 포커스 불가능
+ *
+ * @component
+ * @param {DisabledInputFieldProps} props - DisabledInputField 컴포넌트 속성
+ * @returns {React.ReactElement} 비활성화된 입력 필드 요소
+ */
+export function DisabledInputField({ label, content }: DisabledInputFieldProps) {
+  return (
+    <div className="w-[320px]">
+      {/** label: 높이 19px, 인풋과 간격 0px */}
+      <label className="block h-[19px] leading-[19px] text-body-07 text-neutral-1 whitespace-pre-line mb-0">
+        {label}
+      </label>
+
+      {/** disabled input field: 320x64, 라운드 6px */}
+      <div className="w-full h-16 rounded-[6px] bg-neutral-6 px-4 flex items-center text-body-06 text-neutral-3 whitespace-pre-line cursor-not-allowed">
+        {content}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/input/FlexibleInputField.tsx
+++ b/src/components/ui/input/FlexibleInputField.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import type React from "react"
+
+/**
+ * FlexibleInputFieldProps
+ * @typedef {Object} FlexibleInputFieldProps
+ * @property {string} label - 입력 필드 상단에 표시되는 레이블 텍스트.
+ * @property {boolean} enabled - `true`면 입력 가능한 상태(Editable), `false`면 읽기 전용 표시(Static Box).
+ * @property {string} [text] - 입력 가능한 상태에서 표시될 현재 값(Controlled value).
+ * @property {(text: string) => void} [setText] - 입력 값 변경 콜백. `enabled`가 `true`일 때만 사용됩니다.
+ * @property {string} [content] - 읽기 전용 상태에서 표시할 텍스트 콘텐츠.
+ * @property {string} [placeholder] - 입력 가능한 상태에서의 placeholder 텍스트.
+ */
+interface FlexibleInputFieldProps {
+  label: string
+  enabled: boolean
+  text?: string
+  setText?: (text: string) => void
+  content?: string
+  placeholder?: string
+}
+
+/**
+ * FlexibleInputField
+ *
+ * 단일 컴포넌트로 **입력 가능 상태**와 **읽기 전용 상태**를 전환하여 사용할 수 있는 필드 컴포넌트입니다.
+ *
+ * - `enabled = true`일 때: `<input>`으로 렌더링되며, `text` & `setText`를 통한 **완전 제어(Controlled)** 패턴을 사용합니다.
+ * - `enabled = false`일 때: 회색 배경의 정적 `<div>`로 렌더링되어 값을 표시만 합니다(편집 불가).
+ *
+ * @component
+ * @param {FlexibleInputFieldProps} props - 컴포넌트 속성
+ * @returns {React.ReactElement} 입력 가능/읽기 전용 필드
+ *
+ * @example
+ * // 입력 가능한 상태(Controlled)
+ * const [name, setName] = useState("");
+ * <FlexibleInputField
+ *   label="이름"
+ *   enabled
+ *   text={name}
+ *   setText={setName}
+ *   placeholder="이름을 입력하세요"
+ * />
+ *
+ * @example
+ * // 읽기 전용 상태
+ * <FlexibleInputField
+ *   label="이메일"
+ *   enabled={false}
+ *   content="user@example.com"
+ * />
+ *
+ * @remarks
+ * - `enabled=true`인 경우 `setText`가 제공되지 않으면 입력이 반영되지 않습니다.
+ * - 접근성: 상단 `<label>`은 시각적 안내용이며, 별도의 `id/htmlFor` 연결은 포함하지 않았습니다.
+ */
+export function FlexibleInputField({
+  label,
+  enabled,
+  text,
+  setText,
+  content,
+  placeholder,
+}: FlexibleInputFieldProps) {
+  /**
+   * 입력 값 변경 핸들러.
+   * `enabled`가 `true`이고 `setText`가 전달된 경우에만 상위 상태를 갱신합니다.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} e - 입력 이벤트
+   */
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (enabled && setText) {
+      setText(e.target.value)
+    }
+  }
+
+  return (
+    <div className="w-full space-y-1">
+      {/* label */}
+      <label className="block text-body-07 text-neutral-1 whitespace-pre-line">{label}</label>
+
+      {/* input field */}
+      {enabled ? (
+        <input
+          type="text"
+          value={text || ""}
+          onChange={handleChange}
+          placeholder={placeholder}
+          className="w-full px-3 py-2 bg-neutral-7 border border-neutral-6 rounded-[6px] text-body-06 
+          text-neutral-1 placeholder:text-neutral-3 focus:outline-none focus:ring-2 focus:ring-primary-1 
+          focus:border-transparent transition-all whitespace-pre-line"
+        />
+      ) : (
+        <div
+          className="w-full px-3 py-2 bg-neutral-6 border border-neutral-5 rounded-[6px] text-body-06 
+        text-neutral-2 whitespace-pre-line"
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/input/PasswordInput.tsx
+++ b/src/components/ui/input/PasswordInput.tsx
@@ -4,6 +4,14 @@ import type React from "react"
 import { useState } from "react"
 import { Eye, EyeOff } from "lucide-react"
 
+/**
+ * PasswordInputProps
+ * @typedef {Object} PasswordInputProps
+ * @property {string} value - 비밀번호의 현재 값(Controlled value).
+ * @property {(value: string) => void} onChange - 값이 변경될 때 상위 상태를 갱신하는 콜백.
+ * @property {string} [placeholder] - 입력 필드의 placeholder 텍스트.
+ * @property {string} [label="Password"] - 입력 상단에 표시되는 레이블 텍스트.
+ */
 interface PasswordInputProps {
   value: string
   onChange: (value: string) => void
@@ -11,6 +19,38 @@ interface PasswordInputProps {
   label?: string
 }
 
+/**
+ * PasswordInput
+ *
+ * 비밀번호 입력 전용 컴포넌트로, **표시/숨김 토글 아이콘**을 제공합니다.
+ * - 완전 제어(Controlled) 입력: `value`와 `onChange`를 통해 외부에서 상태를 관리합니다.
+ * - 토글 버튼으로 입력 타입을 `password` ↔ `text` 전환할 수 있습니다.
+ *
+ * @component
+ * @param {PasswordInputProps} props - 컴포넌트 속성
+ * @returns {React.ReactElement} 비밀번호 입력 필드
+ *
+ * @example
+ * // 기본 사용
+ * const [pw, setPw] = useState("");
+ * <PasswordInput
+ *   value={pw}
+ *   onChange={setPw}
+ *   label="비밀번호"
+ *   placeholder="비밀번호를 입력하세요"
+ * />
+ *
+ * @example
+ * // 폼과 함께
+ * <form onSubmit={handleSubmit}>
+ *   <PasswordInput value={pw} onChange={setPw} />
+ *   <button type="submit">로그인</button>
+ * </form>
+ *
+ * @remarks
+ * - 접근성: 토글 버튼은 `aria-label`을 통해 현재 상태에 맞는 대체 텍스트를 제공합니다.
+ * - 시각적 스타일은 Tailwind 유틸리티 클래스로 구성되어 있으며, 부모 컨테이너의 레이아웃에 따라 가로폭이 달라질 수 있습니다.
+ */
 export function PasswordInput({
   value,
   onChange,
@@ -19,17 +59,26 @@ export function PasswordInput({
 }: PasswordInputProps) {
   const [showPassword, setShowPassword] = useState(false)
 
+  /**
+   * 비밀번호 표시/숨김 상태를 전환합니다.
+   */
   const togglePasswordVisibility = () => {
     setShowPassword((prev) => !prev)
   }
 
+  /**
+   * 입력 값 변경 시 상위로 값을 전달합니다.
+   * @param {React.ChangeEvent<HTMLInputElement>} e - 입력 이벤트
+   */
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value)
   }
 
   return (
-    <div className="w-[320px] h-[64px] rounded-[6px] bg-neutral-7 shadow-[0_8px_24px_-6px_rgba(0,0,0,0.04)] 
-        px-[16px] py-[11px] flex flex-col justify-between">
+    <div
+      className="w-[320px] h-[64px] rounded-[6px] bg-neutral-7 shadow-[0_8px_24px_-6px_rgba(0,0,0,0.04)] 
+        px-[16px] py-[11px] flex flex-col justify-between"
+    >
       {/* label */}
       <label className="text-body-08 leading-[14px] tracking-[-0.6px] text-neutral-3">
         {label}
@@ -50,7 +99,7 @@ export function PasswordInput({
           type="button"
           onClick={togglePasswordVisibility}
           className="ml-[8px] flex items-center justify-center h-6 w-6 text-neutral-2 focus:outline-none"
-          aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 표시'}
+          aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 표시"}
         >
           {showPassword ? <EyeOff className="h-6 w-6" /> : <Eye className="h-6 w-6" />}
         </button>

--- a/src/components/ui/input/Toggle.tsx
+++ b/src/components/ui/input/Toggle.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+/**
+ * ToggleSwitchProps
+ * @typedef {Object} ToggleSwitchProps
+ * @property {boolean} isOn - 토글의 ON/OFF 상태를 제어합니다. `true`일 때 토글이 켜진 상태입니다.
+ * @property {(isOn: boolean) => void} setIsOn - 토글의 상태를 변경하는 setter 함수입니다.
+ */
+interface ToggleSwitchProps {
+  isOn: boolean
+  setIsOn: (isOn: boolean) => void
+}
+
+/**
+ * ToggleSwitch
+ *
+ * ON/OFF 상태를 시각적으로 표현하는 토글 스위치 컴포넌트입니다.
+ *
+ * ### 특징
+ * - `isOn` 상태를 기반으로 토글의 위치와 색상이 변경됩니다.
+ * - 클릭 시 `setIsOn` 함수를 호출하여 상위 컴포넌트의 상태를 조작합니다.
+ * - 부드러운 애니메이션으로 토글이 자연스럽게 움직입니다.
+ *
+ * ### 시각적 구성
+ * - OFF 상태: 회색 배경(`#e8ebee`)에 왼쪽에 위치한 흰색 원형 노브
+ * - ON 상태: 파란색 배경(`#0067ac`)에 오른쪽에 위치한 흰색 원형 노브
+ * - 토글 배경과 노브 모두 부드러운 전환 애니메이션 적용
+ *
+ * @component
+ * @param {ToggleSwitchProps} props - ToggleSwitch 컴포넌트 속성
+ * @returns {React.ReactElement} 토글 스위치 요소
+ *
+ * @example
+ * ```tsx
+ * const [isOn, setIsOn] = useState(false)
+ *
+ * <ToggleSwitch
+ *   isOn={isOn}
+ *   setIsOn={setIsOn}
+ * />
+ * ```
+ */
+export function Toggle({ isOn, setIsOn }: ToggleSwitchProps) {
+  /**
+   * 토글 클릭 시 상태를 반전시키는 이벤트 핸들러입니다.
+   */
+  const handleToggle = () => {
+    setIsOn(!isOn)
+  }
+
+  return (
+    <button
+      onClick={handleToggle}
+      className={`relative inline-flex h-[32px] w-[50px] items-center p-[3px] rounded-[15.9091px] transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-1 focus:ring-offset-2 ${
+        isOn ? "bg-primary-1" : "bg-neutral-6"
+      }`}
+      role="switch"
+      aria-checked={isOn}
+    >
+      <span
+        className={`inline-block h-[26px] w-[26px] transform rounded-full bg-neutral-7 [box-shadow:0px_2px_4px_rgba(0,0,0,0.24)] transition-transform duration-300 ease-in-out ${
+          isOn ? "translate-x-[18px]" : "translate-x-0"
+        }`}
+      />
+    </button>
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #7 

## 📝작업 내용

> 토글, 비활성화, 모달용 인풋 컴포넌트 구현

### 스크린샷 (선택)
<img width="457" height="897" alt="image" src="https://github.com/user-attachments/assets/15ca4fa7-f19c-4526-a622-0ba45e1b235d" />

## 💬리뷰 요구사항(선택)

> globals.css의 태그가 누락된 부분이나 디자인, 로직상으로 개선할만한 부분이 있을까요?
