### PR TITLE
[#42]알림-input-confirm 팝업(write) 구현

### DIFF
--- a/src/components/ui/modal/ConfirmInputDialog.tsx
+++ b/src/components/ui/modal/ConfirmInputDialog.tsx
@@ -37,11 +37,7 @@ export function ConfirmInputDialog({
   const [value1, setValue1] = useState(inputVal1)
   const [value2, setValue2] = useState(inputVal2)
   
-  const handleButtonClick = () => {
-    if (onClickBtn) {
-      onClickBtn(value1, value2)
-    }
-  }
+ 
   return (
     <AlertDialog>
       {trigger && <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>}
@@ -79,7 +75,7 @@ export function ConfirmInputDialog({
         </div>
         <AlertDialogFooter className="flex-row p-0 m-0 gap-0">
           <AlertDialogAction
-            onClick={handleButtonClick}
+            onClick={() => onClickBtn?.(value1, value2)}
             className="flex-1 m-0 h-12 rounded-[14px] border-0 hover:bg-transparent transition-colors bg-neutral-7"
           >
             <span className="text-body-04 text-info">{btnText}</span>


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #42 

## 📝작업 내용
> 알림-input-confirm 팝업(write) 컴포넌트 구현

### 스크린샷 (선택)
<img width="514" height="504" alt="image" src="https://github.com/user-attachments/assets/f9b3ff3f-1eb2-4757-9d55-e9b800cb5aa2" />

## 💬리뷰 요구사항(선택)

> 텍스트 작성 시 검은색이 아닌 회색으로 작성 되는데 어떤가요?