### PR TITLE
[#69] 활성화 버튼의 텍스트 색상을 color-monochrome-lightgray로 변경

### DIFF
--- a/src/components/ui/button/BigButtonActivated.tsx
+++ b/src/components/ui/button/BigButtonActivated.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 /**
  * CustomButtonProps
@@ -7,8 +7,8 @@
  * @property {() => void} onClick - 버튼 클릭 시 실행될 콜백 함수입니다.
  */
 interface CustomButtonProps {
-  label: string
-  onClick: () => void
+  label: string;
+  onClick: () => void;
 }
 
 /**
@@ -49,11 +49,11 @@ export function BigButtonActivated({ label, onClick }: CustomButtonProps) {
         w-[327px] h-[56px] p-0
         rounded-[15px] bg-primary-1
         shadow-[0_8px_16px_-6px_rgba(0,82,103,0.32)]
-        text-neutral-6 text-body-06 leading-[19px] font-semibold tracking-[-0.6px]
+        text-monochrome-lightgray text-body-06 leading-[19px] font-semibold tracking-[-0.6px]
         whitespace-pre-line
       "
     >
       {label}
     </button>
-  )
+  );
 }

--- a/src/components/ui/button/MiddleButtonActivated.tsx
+++ b/src/components/ui/button/MiddleButtonActivated.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 /**
  * CustomButtonProps
@@ -7,8 +7,8 @@
  * @property {() => void} onClick - 버튼 클릭 시 실행될 콜백 함수입니다.
  */
 interface CustomButtonProps {
-  label: string
-  onClick: () => void
+  label: string;
+  onClick: () => void;
 }
 
 /**
@@ -49,11 +49,11 @@ export function MiddleButtonActivated({ label, onClick }: CustomButtonProps) {
         w-[200px] h-[56px] p-0
         rounded-[15px] bg-primary-1
         shadow-[0_8px_16px_-6px_rgba(0,82,103,0.32)]
-        text-neutral-6 text-body-06 leading-[19px] font-semibold tracking-[-0.6px]
+        text-monochrome-lightgray text-body-06 leading-[19px] font-semibold tracking-[-0.6px]
         whitespace-pre-line
       "
     >
       {label}
     </button>
-  )
+  );
 }

--- a/src/components/ui/button/SmallButtonActivated.tsx
+++ b/src/components/ui/button/SmallButtonActivated.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 /**
  * CustomButtonProps
@@ -7,8 +7,8 @@
  * @property {() => void} onClick - 버튼 클릭 시 실행될 콜백 함수입니다.
  */
 interface CustomButtonProps {
-  label: string
-  onClick: () => void
+  label: string;
+  onClick: () => void;
 }
 
 /**
@@ -49,11 +49,11 @@ export function SmallButtonActivated({ label, onClick }: CustomButtonProps) {
         w-[159px] h-[56px] p-0
         rounded-[15px] bg-primary-1
         shadow-[0_8px_16px_-6px_rgba(0,82,103,0.32)]
-        text-neutral-6 text-body-06 leading-[19px] font-semibold tracking-[-0.6px]
+        text-monochrome-lightgray text-body-06 leading-[19px] font-semibold tracking-[-0.6px]
         whitespace-pre-line
       "
     >
       {label}
     </button>
-  )
+  );
 }

--- a/src/components/ui/button/TinyButton.tsx
+++ b/src/components/ui/button/TinyButton.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 /**
  * CustomButtonProps
@@ -7,8 +7,8 @@
  * @property {() => void} onClick - 버튼 클릭 시 실행될 콜백 함수입니다.
  */
 interface CustomButtonProps {
-  label: string
-  onClick: () => void
+  label: string;
+  onClick: () => void;
 }
 
 /**
@@ -48,11 +48,11 @@ export function TinyButton({ label, onClick }: CustomButtonProps) {
         relative flex items-center justify-center
         w-[59px] h-[31px] p-0
         rounded-[15px] bg-primary-1
-        text-neutral-6 text-body-07 leading-[17px] font-semibold tracking-[-0.6px]
+        text-monochrome-lightgray text-body-07 leading-[17px] font-semibold tracking-[-0.6px]
         whitespace-pre-line
       "
     >
       {label}
     </button>
-  )
+  );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #69 

## 📝작업 내용
- `text-neutral-6` → `text-monochrome-lightgray`
- 현재 globals.css에 neutral-6이 없어서 검정색으로 보이는 현상 개선
- [x] `BigButtonActivated.tsx` 수정
- [x] `MiddleButtonActivated.tsx` 수정
- [x] `SmallButtonActivated.tsx` 수정
- [x] `TinyButton.tsx` 수정

### 스크린샷

## 💬리뷰 요구사항
