### PR TITLE
[#133] 투자-전체 주식 목록, 주식 상세 페이지 구현

### DIFF
--- a/src/app/(main)/invest/allStockList/page.tsx
+++ b/src/app/(main)/invest/allStockList/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+import { StockList } from "@/components/ui/invest/StockList";
+import { HttpError } from "@/types/axios/httpError.t";
+import api from "@/lib/axios/axios";
+
+import requests from "@/lib/axios/requests"
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const router = useRouter();
+  const [stocks, setStocks] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+
+    (async () => {
+      try {
+        const [stockRes] = await Promise.all([
+          api.get(requests.stockList),
+        ]);
+        // const res = await api.get(requests.stockList);
+        setStocks(stockRes.data ?? []);
+      } catch (e) {
+	      // 커스텀 에러관리
+        const err = e as HttpError;
+        
+        // 403일 경우 에러메시지를 반환하고 홈으로 라우팅
+        if (err.statusCode === 403) {
+          alert(err.message);
+          router.push("/");
+        } else {
+          // 필요 시 다른 에러 처리
+          console.error(err);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+
+  if (loading) {
+    return (
+      <main className="min-h-screen flex justify-center items-center">
+        로딩중...
+      </main>
+    );
+  }
+
+  const handleBuy = (stockId: string) => {
+    router.push(`/invest/buyStock?id=${stockId}`)
+  }
+  return (
+    <div className="w-full bg-primary-4 pb-20">
+      <div className="flex justify-center items-center gap-2 pt-4 pb-7">
+        <h2 className="text-head-06 text-neutral-1">전체 주식 목록</h2>
+        <img src="/icons/refresh.png" alt="새로고침" className="w-5 h-5" />
+      </div>
+      <StockList stocks={stocks} onClickBtn={handleBuy} btnLab="사기"/>
+    </div>
+  )
+}

--- a/src/app/(main)/invest/buyStock/page.tsx
+++ b/src/app/(main)/invest/buyStock/page.tsx
@@ -1,0 +1,105 @@
+"use client"
+import { HttpError } from "@/types/axios/httpError.t";
+import requests from "@/lib/axios/requests"
+import { useEffect, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation";
+import api from "@/lib/axios/axios";
+import { BigButtonActivated } from "@/components/ui/button/BigButtonActivated";
+
+
+export default function Page(){
+  const router = useRouter();
+  const params = useSearchParams();
+  const stockId = params.get("id");
+
+  const [stock, setStock] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!stockId) return;
+    (async () => {
+      try {
+        const res = await api.get(`${requests.stockDetail}?id=${stockId}`);
+        setStock(res.data);
+      } catch (e) {
+	      // 커스텀 에러관리
+        const err = e as HttpError;
+        
+        // 403일 경우 에러메시지를 반환하고 홈으로 라우팅
+        if (err.statusCode === 403) {
+          alert(err.message);
+          router.push("/");
+        } else {
+          // 필요 시 다른 에러 처리
+          console.error(err);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [stockId]);
+
+  if (loading) {
+    return (
+      <main className="min-h-screen flex justify-center items-center">
+        로딩중...
+      </main>
+    );
+  }
+  if (!stock) {
+    return (
+      <div className="flex justify-center items-center h-screen text-neutral-1">
+        데이터를 불러올 수 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Main Content */}
+      <main className="px-6 pt-4 pb-32">
+        {/* Category and Refresh */}
+        <div className="flex items-center justify-center gap-2 mb-17">
+          <span className={`${stock.isPositive ? "text-error" : "text-primary-1"} text-head-06`}>{stock.category_name}</span>
+          <img src="/icons/refresh.png" alt="새로고침 아이콘"className="w-5 h-5" />
+        </div>
+
+        {/* Stock Name */}
+        <h1 className="text-center text-landing-01 text-neutral-1 mb-2">{stock.name}</h1>
+
+        {/* Price and Change */}
+        <div className="text-center mb-5">
+          <span className={`${stock.isPositive ? "text-error" : "text-primary-1"} text-head-06 mr-2`}>{stock.price}원</span>
+          <span className={`${stock.isPositive ? "text-error" : "text-primary-1"} text-head-06`}>{stock.changePercent}%</span>
+        </div>
+
+        {/* Arrow Icon */}
+        <div className="flex justify-center mb-5">
+          <div className="w-47 h-40 bg-monochrome-lightgray rounded-[20px] flex items-center justify-center">
+            <img src={`/images/invest/${stock.isPositive ? "icon_invest_up.png" : "icon_invest_down.png"}`} alt="주식 차트 이미지" className="w-30 h-32"/>
+          </div>
+        </div>
+
+        {/* Stats Text */}
+        <div className="text-center">
+          <p className="text-body-06 text-neutral-1 mb-2">
+            {"어제보다 "}
+            <span className={`${stock.isPositive ? "text-error" : "text-primary-1"} text-head-03`}>{stock.prevDayPriceChange}원</span>
+            {" 올랐어요!"}
+          </p>
+          <p className="text-body-06 text-neutral-1">어제는 {stock.prevDayVolume}명이 이 주식을 사고 팔았어요!</p>
+        </div>
+
+        {/* Info Box */}
+        <div className="rounded-[10px] px-6 py-4 mt-18">
+          <p className="text-body-08 text-neutral-4 text-center">새로고침 시 변동 가격이 반영됩니다.</p>
+        </div>
+
+        {/* Buy Button */}
+        <div className="mt-1">
+          <BigButtonActivated label="주식 사기" onClick={() => alert("주식 구매 기능은 아직 구현되지 않았습니다.")} />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/lib/axios/requests.ts
+++ b/src/lib/axios/requests.ts
@@ -10,6 +10,7 @@ const requests = {
   stockList: `/invest/stockList`,
   investSummary: `/invest/investSummary`,
   dashMyStockList: `/invest/myStockList`,
+  stockDetail: `/invest/stockDetail`,
 };
 
 export default requests;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #133 

## 📝작업 내용

>  투자-전체 주식 목록 페이지 구현
> 데이터 -> 실시간 변동 x, 새로 고침 시 반영
> 주식 목록 api로 받아올지 DB에 저장할지 여부가 확정 되지 않았습니다. 그래서 데이터 변수명은 임의로 작성했습니다. 추후 변경하겠습니다.
> 추후 구현 예정) 주식 사기 버튼 클릭 시 주식 사기 페이지로 이동

### 스크린샷 (선택)
<img width="349" height="760" alt="image" src="https://github.com/user-attachments/assets/52fb804d-80e0-4684-a1db-7bf1ee4aa8d4" />'
<img width="355" height="758" alt="image" src="https://github.com/user-attachments/assets/3c96e8fd-6960-4bcd-ad6d-662139466dee" />
