### PR TITLE
[#138] 회원가입 헤더 뒤로가기 로직 통합 및 상태 초기화 처리

### DIFF
--- a/src/app/(auth)/signup/Step01Terms.tsx
+++ b/src/app/(auth)/signup/Step01Terms.tsx
@@ -11,8 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useRouter } from "next/navigation";
-import { useRegisterStore } from "@/store/registerStore";
 
 /**
  * Step1Terms


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #138

## 📝작업 내용

> 회원가입 플로우 전반의 뒤로가기 로직을 통합했습니다.

- `signup/layout.tsx`에서 `useRegisterStore`를 가져와 뒤로가기 동작에 통합
- 현재 단계가 **1단계(약관 동의)**일 경우, `registerStore.reset()` 호출 후 `/` 경로로 이동
- 2단계 이상일 경우 기존처럼 `prev()` 함수로 이전 단계로 이동
- 모든 회원가입 화면(약관, 역할 선택, 본인인증 등)에서 일관된 뒤로가기 UX 제공

## 💬리뷰 요구사항(선택)

> 현재 `reset()` 호출 시 sessionStorage 기반 상태가 정상적으로 초기화되는지 확인 부탁드립니다.  
> 회원가입 중 “뒤로가기 → 다시 진입” 시 비정상 상태(예: 캐시된 step 값)가 남지 않는지도 함께 점검 부탁드립니다.
