### PR TITLE
[#173] 투자-계좌 생성 완료 페이지 구현

### DIFF
--- a/src/app/(no-footer)/invest/completeCreateAccount/page.tsx
+++ b/src/app/(no-footer)/invest/completeCreateAccount/page.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { BigButtonActivated } from "@/components/ui/button/BigButtonActivated"
+import Image from "next/image"
+import { useRouter } from "next/navigation";
+
+export default function CompleteCreateInvestAccountPage() {
+  const router = useRouter();
+  return (
+    <div className="flex flex-col items-center justify-between px-6 pb-6 pt-20">
+      {/* Success Icon and Message */}
+      <div className="flex flex-col items-center">
+        {/* Blue Checkmark Icon */}
+        <div className="flex h-16 w-16 items-center justify-center mb-4">
+          <img src="/images/invest/icon_invest_check.png" alt="체크 이미지" />
+        </div>
+
+        {/* Success Message */}
+        <h1 className="text-center text-head-01 text-neutral-1">
+          주식 계좌를
+          <br />
+          개설했어요!
+        </h1>
+
+        {/* Illustration */}
+        <div className="relative mt-4 w-[352px] h-[235px]">
+          <Image
+            src="/images/common/illust_common_1.png"
+            alt="Bear and rabbit celebrating with money"
+            fill
+            className="object-contain"
+            priority
+          />
+        </div>
+      </div>
+
+      {/* Bottom Button */}
+      <div className="w-full mt-28">
+        <BigButtonActivated label="투자 홈으로 돌아가기" onClick={() => router.push("/invest")}></BigButtonActivated>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

>  closed #173 

## 📝작업 내용

> 투자-계좌 생성 완료 페이지 구현

### 스크린샷 (선택)
<img width="348" height="750" alt="image" src="https://github.com/user-attachments/assets/1501812d-bb9e-41f3-8e21-2b3662a0680c" />

## 💬리뷰 요구사항(선택)

> 투자 홈으로(모든 메인 페이지 동일) 돌아간 후 < 백 버튼 처리를 어떻게 할까요?
