### PR TITLE
 [#189] 간편 비밀번호 바텀시트 - 불일치 시 에러 처리 추가

### DIFF
--- a/src/components/ui/bottom-sheet/BottomSheetPassword.tsx
+++ b/src/components/ui/bottom-sheet/BottomSheetPassword.tsx
@@ -182,9 +182,11 @@ export function BottomSheetPassword({
           } catch {
             setError(true);
 
-            // 0.5초 뒤 다시 입력할 수 있도록 기본 상태로 복귀
-            setTimeout(() => setError(false), 600);
-            setTimeout(() => setPin(""), 600);
+            // 0.6초 뒤 다시 입력할 수 있도록 기본 상태로 복귀
+            setTimeout(() => {
+              setError(false);
+              setPin("");
+            }, 600);
           }
         }, 200);
       }
@@ -256,19 +258,16 @@ export function BottomSheetPassword({
           <div className="flex justify-center items-center gap-[18px]">
             {Array.from({ length: pinLength }).map((_, i) => {
               const isFilled = pin.length > i;
-              const filledClass = error
-                ? "border-error bg-error"
-                : "border-neutral-4 bg-neutral-4";
-
-              const emptyClass = error
-                ? "border-error bg-transparent"
-                : "border-neutral-4 bg-transparent";
+              const borderColorClass = error
+                ? "border-error"
+                : "border-neutral-4";
+              const filledBgClass = error ? "bg-error" : "bg-neutral-4";
 
               return (
                 <div
                   key={i}
-                  className={`w-4 h-4 rounded-full border ${
-                    isFilled ? filledClass : emptyClass
+                  className={`w-4 h-4 rounded-full border ${borderColorClass} ${
+                    isFilled ? filledBgClass : "bg-transparent"
                   }`}
                 />
               );


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #189 

## 📝작업 내용

> 간편 비밀번호 입력 바텀시트에서 인증 실패 시 에러 표시 및 재입력 흐름 제공
- 에러 발생 시 PIN을 초기화하고 점 스타일로만 시각적 에러를 보여줌으로써, 사용자에게 괴리감 없는 재입력 흐름을 제공하도록 구성함

### 스크린샷
[성공]
<img src="https://github.com/user-attachments/assets/13eec161-7ed0-437f-94cd-afac38ba504e" width="30%" />
[실패]
<img src="https://github.com/user-attachments/assets/3a4d82df-b670-4470-a1d5-2cb64a15aaf9" width="30%" />
