### PR TITLE
[#195] 헤더 없는 페이지 레이아웃 구현

### DIFF
--- a/src/app/(no-header)/headtest/page.tsx
+++ b/src/app/(no-header)/headtest/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Image from "next/image"
+import React, { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+
+/**
+ * QuizStartPage
+ * - 퀴즈 탭의 시작페이지
+ * - 상단 상태바 / 하단 네비게이션은 기본 레이아웃에서 제공
+ * - 본 페이지에서는 배지, 중앙 이미지, 설명 텍스트, 시작 버튼만 렌더링
+ */
+export default function Page() {
+  const router = useRouter()
+  
+  
+
+  return (
+    <main
+      aria-label="퀴즈 시작 페이지"
+      className="relative w-full max-w-[375px] mx-auto h-full max-h-[800px]  mt-[56px] bg-[var(--color-primary-4)] font-[var(--font-sans)] flex flex-col items-center overflow-hidden"
+    >
+      {/* ===============================
+          카드 영역 (중앙 콘텐츠)
+         =============================== */}
+      <div className="relative w-[327px] h-[490px] mx-auto bg-neutral-7 rounded-[16px] shadow-[0_16px_64px_-32px_rgba(0,0,0,0.16)] flex flex-col items-center pt-[160px] pb-[80px] mb-[32px]">
+       
+        {/* 중앙 이미지 */}
+        <div className="absolute top-[135px] w-[262px] h-[262px] mb-8">
+          <Image
+            src="/images/quiz/illust_quiz_credit.png"
+            alt="퀴즈 일러스트"
+            width={262}
+            height={262}
+            priority
+          />
+        </div>
+
+      </div>
+
+      
+      
+    </main>
+  )
+}

--- a/src/app/(no-header)/layout.tsx
+++ b/src/app/(no-header)/layout.tsx
@@ -1,0 +1,44 @@
+// app/(no-header)/layout.tsx
+"use client";
+
+import React from "react";
+import { useUserStore } from "@/store/userStore";
+import { NavigationBar } from "@/components/layout/bar/NavigationBar"
+
+export default function NoHeaderLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { userType } = useUserStore();
+
+  return (
+    // 전체 화면: 상단 상태바 + 컨텐츠 + 하단 네비게이션
+    <div className="w-full h-full bg-neutral-3 flex justify-center">
+      <div className="w-[375px] h-dvh bg-primary-4 flex flex-col overflow-hidden ">
+        {/* Row 1: 상태바 */}
+        <div className="w-full h-[44px] relative">
+          <img
+            src="/images/common/illust_common_status_bar.png"
+            alt="status bar"
+            className="w-full h-full object-cover"
+          />
+        </div>
+
+        {/* Row 2: 컨텐츠 */}
+        <section className="flex-1 overflow-y-auto">
+          {children}
+        </section>
+
+        {/* Row 3: 하단 네비게이션 */}
+        <div className="h-[86px] flex-shrink-0">
+          <NavigationBar
+            userType={userType}
+            onNavigate={() => null}
+            disabled={false}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #195 

## 📝작업 내용

> 헤더 없는 페이지 레이아웃 구현했습니다. 
### 스크린샷
<img width="375" height="810" alt="localhost_3000_headtest" src="https://github.com/user-attachments/assets/007b85fb-4863-43e6-a776-baa16a87c46e" />

## 💬리뷰 요구사항
> (no-header)하단으로 옮기시면 적용됩니다. 주의사항은 56px 빈공간이 생겨서 ui에 변동이 있을겁니다. 저는 고정 수치로 여백을 줬어서 일괄적으로 상단에 여백을 추가하면 해결되는데 비율로 하신 분들은 사용하시려면 조정이 필요할 것 같습니다
