### PR TITLE
[#61] 자녀 대시보드 구현

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -8,6 +8,7 @@ import ParentDashboard from "@/components/custom/home/parent-dashboard/ParentDas
 import requests from "@/lib/axios/requests";
 import api from "@/lib/axios/axios";
 import type { ChildSummary } from "@/types/user";
+import ChildDashboard from "@/components/custom/home/child-dashboard/ChildDashboard";
 
 interface ParentDashboardState {
   balance: number;
@@ -138,7 +139,20 @@ export default function Page() {
   if (userType === "child") {
     return (
       <div className="flex h-full w-full items-center justify-center">
-        <p className="text-body-01">자녀 대시보드</p>
+        <ChildDashboard
+          data={{
+            user: {
+              user_id: 2,
+              name: "김티니",
+              role: "CHILD",
+              email: "child@teenyfinny.com",
+              total_balance: 10000,
+              deposit_balance: 1000,
+              investment_balance: 0,
+              saving_balance: 9000,
+            },
+          }}
+        />
       </div>
     );
   }

--- a/src/components/custom/home/child-dashboard/ChildDashboard.tsx
+++ b/src/components/custom/home/child-dashboard/ChildDashboard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import AboutBanner from "../AboutBanner";
+import { AccountCard } from "@/components/custom/account/AccountCard";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+/**
+ * 사용자 데이터 타입
+ */
+interface UserData {
+  user_id: number;
+  name: string;
+  role: string;
+  email: string;
+  total_balance: number;
+  deposit_balance: number;
+  investment_balance: number;
+  saving_balance: number;
+}
+
+/**
+ * ChildDashboard 컴포넌트 props
+ */
+interface ChildDashboardProps {
+  data: {
+    user: UserData;
+  };
+}
+
+/**
+ * 자녀 대시보드 컴포넌트
+ *
+ * 사용자의 계좌 요약과 카드/상세보기 버튼, 소비 리포트 버튼을 렌더링합니다.
+ *
+ * @param {ChildDashboardProps} props - 대시보드 데이터
+ * @returns {JSX.Element} 자녀 대시보드 화면
+ *
+ * @example
+ * ```tsx
+ * const data = {
+ *   user: {
+ *     user_id: 2,
+ *     name: "김티니",
+ *     role: "CHILD",
+ *     email: "child@teenyfinny.com",
+ *     total_balance: 10000,
+ *     deposit_balance: 1000,
+ *     investment_balance: 0,
+ *     saving_balance: 9000
+ *   }
+ * };
+ *
+ * <ChildDashboard data={data} />
+ * ```
+ */
+export default function ChildDashboard({ data }: ChildDashboardProps) {
+  const { user } = data;
+  const userId = user.user_id;
+
+  /**
+   * 상세 내역 보기 클릭 이벤트
+   *
+   * @param {string} accountName - 클릭한 계좌 이름
+   */
+  const handleViewDetails = (accountName: string) => {
+    console.log(`(id=${userId})인 아이의 ${accountName} 상세 내역 보기`);
+  };
+
+  /**
+   * 카드 뱃지 클릭 이벤트
+   */
+  const handleViewCard = () => {
+    console.log(`(id=${userId})인 아이의 카드 바텀시트 리다이렉트`);
+  };
+
+  /**
+   * 리포트 페이지 이동 이벤트
+   */
+  const reportHandler = () => {
+    console.log(`(id=${userId})인 아이의 리포트 페이지와 리다이렉트`);
+  };
+
+  return (
+    <div className="max-h-screen px-[17px]">
+      <div className="max-w-md mx-auto space-y-3">
+        {/* 배너 */}
+        <div className="flex flex-col gap-6">
+          <AboutBanner />
+        </div>
+
+        {/* 계좌 제목 */}
+        <div className="h-[21px] flex justify-between items-center">
+          <p className="text-head-03 font-bold text-neutral-3 mb-[10px] mt-[20px]">
+            {user.name}의 계좌
+          </p>
+        </div>
+
+        {/* 총 잔액 */}
+        <div className="text-head-00 font-bold text-neutral-1 mb-5">
+          {user.total_balance} 원
+        </div>
+
+        {/* 계좌 카드: 용돈 계좌 */}
+        <AccountCard
+          accountName="용돈 계좌"
+          balance={user.deposit_balance}
+          showCard={true}
+          onViewDetails={() => handleViewDetails("용돈 계좌")}
+          onCardClick={() => handleViewCard()}
+        />
+
+        {/* 계좌 카드: 투자 계좌 */}
+        <AccountCard
+          accountName="투자 계좌"
+          balance={user.investment_balance}
+          onViewDetails={() => handleViewDetails("투자 계좌")}
+          onCardClick={() => null}
+        />
+
+        {/* 계좌 카드: 목표 적금 */}
+        <AccountCard
+          accountName="목표 적금"
+          balance={user.saving_balance}
+          onViewDetails={() => handleViewDetails("목표 적금")}
+          onCardClick={() => null}
+        />
+
+        {/* 소비 리포트 버튼 */}
+        <button
+          className="flex justify-start w-[335px] h-[48px] border-1 border-monochrome-gray
+                     bg-neutral-7 rounded-4xl text-body-04 items-center mt-0"
+          onClick={() => reportHandler()}
+        >
+          <img
+            src="/images/account/illust_account_report.png"
+            alt="리포트 아이콘"
+            className="ml-[12px] mr-[7px] w-[40px] h-[40px]"
+          />
+          소비 리포트 보러가기
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
자녀 대시보드 구현

## #️⃣연관된 이슈

> closed #61 

## 📝작업 내용

> 자녀 대시보드(홈화면)을 구현하였습니다. 

### 스크린샷

<img width="375" height="810" alt="localhost_3000_" src="https://github.com/user-attachments/assets/1518bae2-bcdd-4a93-8de5-462cd0d640cc" />


## 💬리뷰 요구사항
> 간격이 미세하게 다른데, 부모의 자녀 대시보드 화면과 우선 통일하였고, 컴포넌트의 구성이 피그마와 조금 다른 부분들이 있어서 나중에 수정해야할것 같습니다. 