### PR TITLE
[#303] 계좌 개설 API 응답 필드명 불일치 문제 수정

### DIFF
--- a/src/app/(no-footer)/allowance/account/create/Step07ChildInfo.tsx
+++ b/src/app/(no-footer)/allowance/account/create/Step07ChildInfo.tsx
@@ -118,7 +118,7 @@ export default function Step07ChildInfoInput({
 
       const res = await api.post(requests.submitChildInfo, req);
 
-      if (res.data.isSuccess) {
+      if (res.data?.isSuccess) {
         setIsPasswordSheetOpen(false);
         console.log("개설완료")
         onNext();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #303

## 📝작업 내용

> 계좌 개설 api 의 응답값을 verified -> isSuccess로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
