### PR TITLE
[#305] 카드 이름명 동기화 문제 수정

### DIFF
--- a/src/components/custom/allowance/card/CardDetail.tsx
+++ b/src/components/custom/allowance/card/CardDetail.tsx
@@ -63,7 +63,12 @@ export function CardDetail({
 
   // 카드 이름 수정 상태 관리
   const [isEditing, setIsEditing] = useState(false); // 수정 모드 여부
-  const [cardName, setCardName] = useState(initialCardName); // 수정 가능한 카드 이름 값
+  const [cardName, setCardName] = useState(initialCardName);
+
+  // props 변경 → state 갱신
+  useEffect(() => {
+    setCardName(initialCardName);
+  }, [initialCardName]);
 
   /** 바텀시트 열림 상태에 따라 body 스크롤 방지 */
   useEffect(() => {
@@ -145,7 +150,13 @@ export function CardDetail({
           className="absolute top-[40px] right-[30px] text-neutral-2 hover:text-neutral-1"
           aria-label="닫기"
         >
-          <Image src="/icons/x.png" alt="닫기" width={27} height={27} unoptimized />
+          <Image
+            src="/icons/x.png"
+            alt="닫기"
+            width={27}
+            height={27}
+            unoptimized
+          />
         </button>
 
         {/* 카드 상세 정보 영역 */}
@@ -187,7 +198,9 @@ export function CardDetail({
               </>
             ) : (
               <>
-                <p className="text-head-08 text-neutral-1 mt-[17px]">{cardName}</p>
+                <p className="text-head-08 text-neutral-1 mt-[17px]">
+                  {cardName}
+                </p>
                 <div className="mt-[12px] border-b border-monochrome-gray" />
               </>
             )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #305 

## 📝작업 내용

> 카드 정보 조회할때 카드 이름이 동기화되지 않고 공백으로 처리되는 문제 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
