### PR TITLE
[#218, #213] 마이페이지 - 서비스 이용 약관 페이지 구현

### DIFF
--- a/src/app/(main)/profile/terms/page.tsx
+++ b/src/app/(main)/profile/terms/page.tsx
@@ -1,0 +1,15 @@
+export default function TermsServicePage() {
+
+  return (
+    <main className="flex flex-col h-full bg-neutral-7">
+      {/* 본문 (HTML 파일 iframe) */}
+      <div className="flex-1 px-[27px] pb-[20px]">
+        <iframe
+            title="서비스 이용 약관"
+            src="/terms/terms_service.html"
+            className="w-full h-full border-0 no-scrollbar"
+        />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #218, closed #213 

## 📝작업 내용

> iframe 기반 서비스 이용 약관 페이지 구현
- figma와 차이점: 확인 버튼 삭제 
  - 상단에 뒤로가기 버튼이 있어서 불필요하다 생각되었습니다.

### 스크린샷
<img width="40%" alt="localhost_3000_profile (1)" src="https://github.com/user-attachments/assets/f960ca45-1f15-4910-8fd0-92ee873d17b4" />

