### PR TITLE
[#313] 가입 완료 후 세션 초기화 및 후속 이동 경로 정리

### DIFF
--- a/src/app/(auth)/signup/complete/page.tsx
+++ b/src/app/(auth)/signup/complete/page.tsx
@@ -59,12 +59,13 @@ export default function SignupCompletePage() {
 
       {/* 하단 버튼 */}
       <div className="fixed bottom-[56px] w-full max-w-[327px]">
-        {role === "PARENT" ? (
+        {role === "PARENT" && (
           <BigButtonActivated
             label="내 계좌 불러오기"
             onClick={() => router.push("/home")}
           />
-        ) : (
+        )}
+        {role === "CHILD" && (
           <BigButtonActivated
             label="가족 등록하기"
             onClick={() => router.push("/family/info")}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #313 

## 📝작업 내용

> 가입 완료 후 세션 초기화 및 후속 이동 경로 정리
- 회원가입 완료 후 sessionStorage 정리는 fix인데 feat라고 작성했네요. 다음부터는 주의하겠습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
