### PR TITLE
[#439] 소비리포트 스크롤바 안 보이게 수정

### DIFF
--- a/src/app/(main)/allowance/report/page.tsx
+++ b/src/app/(main)/allowance/report/page.tsx
@@ -84,7 +84,7 @@ console.log("selectedChildId", selectedChildId);
     report?.comparedType === "more" ? "더 썼어요" : "아꼈어요";
 
   return (
-    <div className="px-[27px] pb-[20px]">
+    <div className="h-full overflow-y-auto [&::-webkit-scrollbar]:hidden px-[27px] pb-[20px]">
       {/* ------ 상단 Header ------ */}
       <div className="flex flex-col mt-[16px]">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #439

## 📝작업 내용

> 소비리포트에서 카테고리 리스트가 해당 영역을 벗어날 경우 스크롤바 생김
> 스크롤바를 안보이게 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
